### PR TITLE
add github action

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -1,0 +1,166 @@
+# name: Qiita Plugin CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml
+  main:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        # Docker Hub image
+        image: postgres:13.4
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
+          - 5432/tcp
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setup for conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: "3.8"
+
+      # we need to download qiita directly so we have "easy" access to
+      # all config files
+      - name: Checkout qiita dev codebase
+        uses: actions/checkout@v4
+        with:
+          repository: qiita-spots/qiita
+          ref: dev
+          path: qiita-dev
+
+      - name: Basic dependencies install
+        shell: bash -l {0}
+        run: |
+          echo "Testing: "
+
+          # pull out the port so we can modify the configuration file easily
+          pgport=${{ job.services.postgres.ports[5432] }}
+          sed -i "s/PORT = 5432/PORT = $pgport/" qiita-dev/qiita_core/support_files/config_test.cfg
+
+          # PGPASSWORD is read by pg_restore, which is called by the build_db process.
+          export PGPASSWORD=postgres
+
+          # Setting up main qiita conda environment
+          conda config --add channels conda-forge
+          conda create -q --yes -n qiita python=3.9 libgfortran numpy nginx cython redis
+          conda activate qiita
+          pip install sphinx sphinx-bootstrap-theme pytest-cov Click
+
+      - name: Qiita install
+        shell: bash -l {0}
+        run: |
+          conda activate qiita
+
+          pip install qiita-dev/ --no-binary redbiom
+          mkdir ~/.qiita_plugins
+
+      - name: Install Qiita plugins
+        shell: bash -l {0}
+        run: |
+          wget https://data.qiime2.org/distro/core/qiime2-2022.8-py38-linux-conda.yml
+          sed -n '/channels/,/dependencies/p' qiime2-2022.8-py38-linux-conda.yml > tinyq2.yml && \
+          echo "  - q2-metadata=2022.8" >> tinyq2.yml && \
+          echo "  - q2-mystery-stew=2022.8" >> tinyq2.yml && \
+          echo "  - q2-types=2022.8" >> tinyq2.yml && \
+          echo "  - q2cli=2022.8" >> tinyq2.yml && \
+          echo "  - q2templates=2022.8" >> tinyq2.yml && \
+          echo "  - qiime2=2022.8" >> tinyq2.yml && \
+          echo "  - q2-feature-table=2022.8" >> tinyq2.yml
+
+          conda config --set channel_priority strict
+          conda env create --quiet -n qtp-visualization --file tinyq2.yml
+          conda activate qtp-visualization
+          
+          export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
+          export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
+
+          export ENVIRONMENT="source /home/runner/.profile; conda activate qtp-visualization"
+          pip install -e .
+          pip --quiet install coveralls
+
+          configure_visualization_types --env-script 'source /home/runner/.profile; conda activate qtp-visualization; export ENVIRONMENT="source /home/runner/.profile; conda activate qtp-visualization"' --ca-cert $QIITA_ROOTCA_CERT
+
+          echo "Available Qiita plugins"
+          ls ~/.qiita_plugins/
+
+      - name: Starting Main Services
+        shell: bash -l {0}
+        run: |
+          conda activate qiita
+          export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
+          export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" `pwd`/qiita-dev/qiita_core/support_files/config_test.cfg > ${QIITA_CONFIG_FP}
+
+          export REDBIOM_HOST="http://localhost:7379"
+
+          echo "1. Setting up redis"
+          redis-server --daemonize yes --port 7777
+
+          echo "2. Setting up nginx"
+          mkdir -p ${CONDA_PREFIX}/var/run/nginx/
+          export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
+          export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
+          sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          nginx -c ${NGINX_FILE_NEW}
+
+          echo "3. Setting up qiita"
+          qiita-env make --no-load-ontologies
+          qiita plugins update
+          qiita-test-install
+
+          echo "4. Starting supervisord => multiple qiita instances"
+          supervisord -c ${PWD}/qiita-dev/qiita_pet/supervisor_example.conf
+          sleep 10
+          cat /tmp/supervisord.log
+
+      - name: qtp-visualization
+        shell: bash -l {0}
+        run: |
+          conda activate qtp-visualization
+          export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
+          export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
+          export PYTHONWARNINGS="ignore:Certificate for localhost has no \`subjectAltName\`"
+          export ENVIRONMENT="source /home/runner/.profile; conda activate qtp-visualization"
+
+          pytest qtp-visualization --doctest-modules --cov=qtp-visualization --cov-report=lcov --ignore=qtp-visualization/data
+
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ruff
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: install dependencies
+        run: python -m pip install --upgrade pip
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: lint
+        run: |
+          pip install -q ruff
+          ruff check .

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
 
 jobs:
   # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    branches: [master, fix_ghaction]
 
 jobs:
   # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -2,9 +2,8 @@
 
 on:
   push:
-    branches: [master]
+    branches: [ dev ]
   pull_request:
-    branches: [master, fix_ghaction]
 
 jobs:
   # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml


### PR DESCRIPTION
Hi @antgonza,
the qtp-visualization plugin seems to lack github action workflows for testing and linting (maybe it was created together with qtp-diversity?!). Thus PR shall add an according action - but I doubt it will pass as is. Since no action is registered, I cannot test this atm. Once you merge, I will start on executing the actual python tests.